### PR TITLE
docs: update documentation after merge to main (a5e4be3)

### DIFF
--- a/docs/copilot-cli-plugins.md
+++ b/docs/copilot-cli-plugins.md
@@ -13,7 +13,7 @@ The source-of-truth skill contracts still live under `skills/`. The `plugins/` t
 Register this repository as a marketplace:
 
 ```bash
-copilot plugin marketplace add Tyler-R-Kendrick/copilot-apo
+copilot plugin marketplace add Tyler-R-Kendrick/copilot-auto-training
 ```
 
 Inspect the published plugins:
@@ -43,7 +43,7 @@ In an interactive Copilot CLI session, use `/skills list` to confirm the bundled
 If you do not want to register the marketplace first, install a plugin from its repository subdirectory:
 
 ```bash
-copilot plugin install Tyler-R-Kendrick/copilot-apo:plugins/copilot-training
+copilot plugin install Tyler-R-Kendrick/copilot-auto-training:plugins/copilot-training
 ```
 
 ## Update Or Remove

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -30,7 +30,7 @@ COPILOT_MODEL=default
 COPILOT_TIMEOUT_SECONDS=180
 ```
 
-Start from [/.env.sample](/workspaces/copilot-apo/.env.sample) so the supported Copilot settings stay documented in one place.
+Start from [/.env.sample](../.env.sample) so the supported Copilot settings stay documented in one place.
 
 `COPILOT_TIMEOUT_SECONDS` controls the per-request SDK timeout used by optimizer-backed validation and inference calls. The default is 180 seconds, which gives slower validations more time to finish before the runtime declares a timeout.
 
@@ -130,7 +130,7 @@ python -m pytest -q
 If you want to use the repo's skills through Copilot CLI instead of running the local Python scripts directly, add this repository as a plugin marketplace:
 
 ```bash
-copilot plugin marketplace add Tyler-R-Kendrick/copilot-apo
+copilot plugin marketplace add Tyler-R-Kendrick/copilot-auto-training
 copilot plugin install copilot-training@copilot-training
 ```
 


### PR DESCRIPTION
Fixes stale repository name references introduced in #55 (the initial commit that added the `update-docs` workflow along with the full repository content).

## Changes

- **`docs/getting-started.md`** — Replaced two occurrences of the outdated repo name `Tyler-R-Kendrick/copilot-apo` with the correct `Tyler-R-Kendrick/copilot-auto-training` in plugin marketplace commands. Also fixed the absolute devcontainer path `/workspaces/copilot-apo/.env.sample` to a repository-relative link `../.env.sample`.
- **`docs/copilot-cli-plugins.md`** — Replaced two occurrences of `Tyler-R-Kendrick/copilot-apo` with `Tyler-R-Kendrick/copilot-auto-training` in the marketplace registration and direct-install commands.

## Push range

`0000000000000000000000000000000000000000`...`a5e4be35a8c3efb5bd5cce608e163e1de72e4b30`




> Generated by [Update Docs](https://github.com/Tyler-R-Kendrick/copilot-auto-training/actions/runs/24319675393/agentic_workflow) · ● 935.9K · [◷](https://github.com/search?q=repo%3ATyler-R-Kendrick%2Fcopilot-auto-training+%22gh-aw-workflow-id%3A+update-docs%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Update Docs, engine: copilot, model: auto, id: 24319675393, workflow_id: update-docs, run: https://github.com/Tyler-R-Kendrick/copilot-auto-training/actions/runs/24319675393 -->

<!-- gh-aw-workflow-id: update-docs -->