### PR TITLE
docs: update documentation after merge to main (81e7263)

### DIFF
--- a/skills/trainer-optimize/SKILL.md
+++ b/skills/trainer-optimize/SKILL.md
@@ -208,6 +208,6 @@ Copilot `.env` example at the repository root:
 COPILOT_MODEL=default
 ```
 
-Use [/.env.sample](/workspaces/copilot-apo/.env.sample) as the canonical template for the supported Copilot setting.
+Use [/.env.sample](../../.env.sample) as the canonical template for the supported Copilot setting.
 
 See `references/dataset-format.md` for the dataset contract and `assets/examples.md` for worked examples.


### PR DESCRIPTION
## Summary

Post-merge documentation review triggered by commit `81e726315ba0b9eeb41a339c9b85f187d297722c`.

**Push range:** (grafted) ... `81e726315ba0b9eeb41a339c9b85f187d297722c`

## Files Changed

- **`skills/trainer-optimize/SKILL.md`** — Replaced stale absolute devcontainer path `/workspaces/copilot-apo/.env.sample` (which used the old repository name `copilot-apo`) with the correct relative path `../../.env.sample`, consistent with the reference already used in `docs/getting-started.md`.

## Review Notes

All other documentation files (`README.md`, `docs/getting-started.md`, `docs/copilot-cli-plugins.md`, `docs/dashboard.md`, `docs/troubleshooting.md`, `docs/copilot_execution_plan.md`, `examples/first-run/README.md`, and remaining `skills/*/SKILL.md` files) were reviewed and found accurate relative to the current source code.




> Generated by [Update Docs](https://github.com/Tyler-R-Kendrick/copilot-auto-training/actions/runs/24320543154/agentic_workflow) · ● 1.1M · [◷](https://github.com/search?q=repo%3ATyler-R-Kendrick%2Fcopilot-auto-training+%22gh-aw-workflow-id%3A+update-docs%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Update Docs, engine: copilot, model: auto, id: 24320543154, workflow_id: update-docs, run: https://github.com/Tyler-R-Kendrick/copilot-auto-training/actions/runs/24320543154 -->

<!-- gh-aw-workflow-id: update-docs -->